### PR TITLE
Enable saving during QueueInferTextAsync processing

### DIFF
--- a/LLamaStack.Core/Services/IModelSessionService.cs
+++ b/LLamaStack.Core/Services/IModelSessionService.cs
@@ -6,6 +6,7 @@ namespace LLamaStack.Core.Services
 {
     public interface IModelSessionService<T> where T : IEquatable<T>, IComparable<T>
     {
+        int InferQueueCount { get; }
         Task<ModelSessionState<T>> GetAsync(T sessionId);
         Task<IEnumerable<ModelSessionState<T>>> GetAllAsync();
 
@@ -14,7 +15,7 @@ namespace LLamaStack.Core.Services
         Task<ModelSession<T>> CreateAsync(T sessionId, ISessionConfig sessionConfig, IInferenceParams inferenceParams = null, CancellationToken cancellationToken = default);
         Task<string> InferTextAsync(T sessionId, string prompt, IInferenceParams inferenceParams = null, CancellationToken cancellationToken = default);
         IAsyncEnumerable<InferTokenModel> InferAsync(T sessionId, string prompt, IInferenceParams inferenceParams = null, CancellationToken cancellationToken = default);
-        Task<string> QueueInferTextAsync(T sessionId, string prompt, IInferenceParams inferenceParams = null, CancellationToken cancellationToken = default);
+        Task<string> QueueInferTextAsync(T sessionId, string prompt, IInferenceParams inferenceParams = null, bool saveOnComplete = false, CancellationToken cancellationToken = default);
 
         Task<bool> RemoveAsync(T sessionId);
         Task<ModelSession<T>> LoadAsync(T sessionId, CancellationToken cancellationToken = default);


### PR DESCRIPTION
Calling `SaveAsync` on a session after a call to `QueueInferTextAsync` causes an expetion as the `ModelSession` is busy as mentioned in this issue [Issue #1](https://github.com/saddam213/LLamaStack/issues/1#issue-1867814967)

This causes 1 of 2 conditions
1. `SaveAsync` locks the session blocking `InferAsync`
2. `InferAsync` locks the session blocking `SaveAsync`

This behaviour is by design as you can't save a session while its running inference (without cancelation) however it presents a challage to the end user on how/when to save a session if they are using the InferQueue

I have made some changes to the ModelSessionService API to expose the InferQueueCount and also allow a flag `SaveOnComplete` to be set on the queued request that will save the session when the queue has finished processing the item, although not the final approch it will resolve the current issue.
